### PR TITLE
Lowered SwiftPM iOS version to 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "TLIndexPathTools",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v9)
     ],
     products: [
         .library(name: "TLIndexPathTools",


### PR DESCRIPTION
Thank you for making changes required to support Swift Package Manager.
The original project has deployment target set as iOS8. Setting the same in Package.swift results in a warning when using Xcode 12. But it should be possible to lower platform support to iOS9.